### PR TITLE
Add GBP to DKK conversion

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -588,6 +588,22 @@
             align-items: center;
             gap: 5px;
         }
+
+        .exchange-rate {
+            background: #f8f9fa;
+            padding: 8px 15px;
+            border-radius: 20px;
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
+
+        .exchange-rate input {
+            width: 80px;
+            padding: 5px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
         
         /* Pagination */
         .pagination {

--- a/public/index.html
+++ b/public/index.html
@@ -75,6 +75,11 @@
                 <i class="fas fa-check-circle"></i>
                 <span id="selectedProductsCount">0</span> valgte
             </div>
+
+            <div class="exchange-rate">
+                <label for="exchangeRate">GBP→DKK</label>
+                <input type="number" id="exchangeRate" value="8.5" step="0.01" style="width:80px;">
+            </div>
             
             <button class="btn btn-success" onclick="sendToWooCommerce()">
                 <i class="fas fa-paper-plane"></i> Send til WooCommerce

--- a/public/js/filehandling.js
+++ b/public/js/filehandling.js
@@ -1,5 +1,19 @@
 // File handling and CSV import/export for ralawise-v2
 
+// Default exchange rate from GBP to DKK. Can be adjusted via the
+// input field with id="exchangeRate" in index.html.
+window.GBP_TO_DKK_RATE = 8.5;
+
+// Convert a price in GBP to DKK using the configurable exchange rate
+// If the provided value is empty or not numeric, an empty string is returned
+function convertGBPtoDKK(gbp) {
+    const rateInput = document.getElementById('exchangeRate');
+    const rate = rateInput ? parseFloat(rateInput.value) : window.GBP_TO_DKK_RATE;
+    const val = parseFloat(gbp);
+    if (isNaN(val) || isNaN(rate)) return '';
+    return (val * rate).toFixed(2);
+}
+
 function handleParentFile(event) {
     const file = event.target.files[0];
     if (file) {
@@ -121,12 +135,14 @@ function exportToCSV() {
                 Kategori: item.data['tax:product_cat'] || ''
             });
         } else {
+            const priceGBP = editedData.get(`${item.data.sku}_price`) ?? item.data.regular_price;
+            const priceDKK = convertGBPtoDKK(priceGBP);
             csvData.push({
                 Type: 'Variation',
                 Produktnavn: item.parent.post_title || '',
                 SKU: item.data.sku || '',
                 Status: item.data.stock_status || '',
-                Pris: item.data.regular_price || '',
+                Pris: priceDKK,
                 Farve: item.data['meta:attribute_Colour'] || '',
                 Størrelse: item.data['meta:attribute_Size'] || '',
                 Brand: item.parent['attribute:pa_Brand'] || '',

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -145,7 +145,18 @@ function sendToWooCommerce() {
     if (!confirm(`Er du sikker på du vil sende ${selectedProducts.size} produkter til ${shop.name}?`)) {
         return;
     }
+    const productsToSend = [];
+    selectedProducts.forEach(sku => {
+        const item = combinedData.find(i => i.data.sku === sku && i.type === 'variation');
+        if (item) {
+            const priceGBP = editedData.get(`${sku}_price`) ?? item.data.regular_price;
+            const priceDKK = convertGBPtoDKK(priceGBP);
+            productsToSend.push({ sku: sku, price: priceDKK });
+        }
+    });
+
     alert(`Sender ${selectedProducts.size} produkter til ${shop.name}...\n\nDette er en demo. I en rigtig applikation ville dette sende produkterne via WooCommerce REST API.`);
+    console.log('Produkter der sendes:', productsToSend);
 
     selectedProducts.clear();
     document.querySelectorAll('.product-checkbox').forEach(cb => (cb.checked = false));


### PR DESCRIPTION
## Summary
- add configurable GBP→DKK exchange rate and conversion function
- export prices in DKK
- convert prices when sending to WooCommerce
- expose exchange rate input on the page with styling

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688cd03f5f78833395b84f83711cc0fc