### PR TITLE
Add VAT toggle with configurable rate

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -588,6 +588,17 @@
             align-items: center;
             gap: 5px;
         }
+
+        .vat-toggle {
+            background: #f8f9fa;
+            padding: 8px 15px;
+            border-radius: 20px;
+            font-weight: bold;
+            color: #007bff;
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
         
         /* Pagination */
         .pagination {

--- a/public/index.html
+++ b/public/index.html
@@ -70,6 +70,10 @@
             </div>
             
             <input type="text" class="search-box" id="searchBox" placeholder="🔍 Søg efter produktnavn, SKU eller farve...">
+
+            <label class="vat-toggle">
+                <input type="checkbox" id="vatToggle"> Inkl. moms
+            </label>
             
             <div class="selected-count">
                 <i class="fas fa-check-circle"></i>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -14,6 +14,10 @@ window.itemsPerPage = 25;
 window.totalPages = 1;
 window.filteredData = [];
 
+// VAT settings
+window.VAT_RATE = 0.25; // 25%
+window.includeVAT = false;
+
 // DOM Elements
 window.shopManagerModal = document.getElementById('shopManagerModal');
 window.shopSelect = document.getElementById('shopSelect');
@@ -22,12 +26,17 @@ window.selectedProductsCount = document.getElementById('selectedProductsCount');
 window.paginationControls = document.getElementById('paginationControls');
 window.shopListSection = document.getElementById('shopListSection');
 window.shopFormSection = document.getElementById('shopFormSection');
+window.vatToggle = document.getElementById('vatToggle');
 
 // Initialisering af event listeners
 document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('parentFile').addEventListener('change', window.handleParentFile);
     document.getElementById('variationFile').addEventListener('change', window.handleVariationFile);
     document.getElementById('searchBox').addEventListener('input', window.filterProducts);
+    document.getElementById('vatToggle').addEventListener('change', function(e) {
+        window.includeVAT = e.target.checked;
+        if (window.displayProducts) window.displayProducts();
+    });
 
     if (window.setupDragAndDrop) {
         window.setupDragAndDrop('parentUploadBox', 'parentFile', window.handleParentFile);

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -83,18 +83,23 @@ function displayProducts() {
                 variationRow.classList.add('hidden-variation');
             }
             variationRow.setAttribute('data-parent-sku', parent.sku);
-            const currentPrice = editedData.get(`${variation.sku}_price`) || variation.regular_price || '';
+            const basePrice = editedData.get(`${variation.sku}_price`) || variation.regular_price || '';
+            let displayPrice = basePrice;
+            const numPrice = parseFloat(basePrice);
+            if (!isNaN(numPrice) && includeVAT) {
+                displayPrice = (numPrice * (1 + VAT_RATE)).toFixed(2);
+            }
             const currentCategory = editedData.get(`${parent.sku}_category`) || parent['tax:product_cat'] || '';
             variationRow.innerHTML = `
                 <td class="checkbox-cell">
-                    <input type="checkbox" class="product-checkbox" data-sku="${variation.sku}" 
-                        data-type="variation" data-parent-sku="${parent.sku}" 
+                    <input type="checkbox" class="product-checkbox" data-sku="${variation.sku}"
+                        data-type="variation" data-parent-sku="${parent.sku}"
                         ${isSelectedVar ? 'checked' : ''} onchange="toggleProductSelection(this)">
                 </td>
                 <td>${parent.post_title || ''}</td>
                 <td>${variation.sku || ''}</td>
                 <td><span class="stock-status stock-${variation.stock_status}">${variation.stock_status || ''}</span></td>
-                <td class="editable" contenteditable="true" data-field="price" data-sku="${variation.sku}" onblur="saveEdit(this)">£${currentPrice}</td>
+                <td class="editable" contenteditable="true" data-field="price" data-sku="${variation.sku}" onblur="saveEdit(this)">£${displayPrice}</td>
                 <td>${variation['meta:attribute_Colour'] || ''}</td>
                 <td>${variation['meta:attribute_Size'] || ''}</td>
                 <td>${parent['attribute:pa_Brand'] || ''}</td>

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -56,7 +56,9 @@ function saveEdit(element) {
         value = value.replace('£', '');
         if (value && !isNaN(value)) {
             editedData.set(`${sku}_price`, value);
-            element.textContent = `£${value}`;
+            const num = parseFloat(value);
+            const displayValue = includeVAT ? (num * (1 + VAT_RATE)).toFixed(2) : value;
+            element.textContent = `£${displayValue}`;
             element.style.background = '#d1ecf1';
             setTimeout(() => { element.style.background = ''; }, 1000);
         } else if (value === '') {


### PR DESCRIPTION
## Summary
- enable showing prices with VAT via new toggle
- store VAT rate in `main.js`
- render variation prices depending on VAT toggle
- update edited prices to use the toggle
- style and add the VAT toggle to the page controls

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688cd03e021c8333948de676c57971a9