### PR TITLE
Add profit margin input and calculations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -83,6 +83,11 @@
                 <label for="exchangeRate">GBP→DKK</label>
                 <input type="number" id="exchangeRate" value="8.5" step="0.01" style="width:80px;">
             </div>
+
+            <div class="exchange-rate">
+                <label for="profitMargin">Profit %</label>
+                <input type="number" id="profitMargin" value="0" step="0.01" style="width:80px;">
+            </div>
             
             <button class="btn btn-success" onclick="sendToWooCommerce()">
                 <i class="fas fa-paper-plane"></i> Send til WooCommerce

--- a/public/js/filehandling.js
+++ b/public/js/filehandling.js
@@ -3,6 +3,16 @@
 // Default exchange rate from GBP to DKK. Can be adjusted via the
 // input field with id="exchangeRate" in index.html.
 window.GBP_TO_DKK_RATE = 8.5;
+// Default profit margin percentage applied to prices
+window.profitMarginPercent = 0;
+
+// Apply profit margin to a GBP price
+function applyProfitMargin(gbp) {
+    const val = parseFloat(gbp);
+    const margin = parseFloat(window.profitMarginPercent) || 0;
+    if (isNaN(val)) return val;
+    return val * (1 + margin / 100);
+}
 
 // Convert a price in GBP to DKK using the configurable exchange rate
 // If the provided value is empty or not numeric, an empty string is returned
@@ -136,7 +146,8 @@ function exportToCSV() {
             });
         } else {
             const priceGBP = editedData.get(`${item.data.sku}_price`) ?? item.data.regular_price;
-            const priceDKK = convertGBPtoDKK(priceGBP);
+            const withProfit = applyProfitMargin(priceGBP);
+            const priceDKK = convertGBPtoDKK(withProfit);
             csvData.push({
                 Type: 'Variation',
                 Produktnavn: item.parent.post_title || '',

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -14,6 +14,9 @@ window.itemsPerPage = 25;
 window.totalPages = 1;
 window.filteredData = [];
 
+// Profit margin
+window.profitMarginPercent = 0;
+
 // VAT settings
 window.VAT_RATE = 0.25; // 25%
 window.includeVAT = false;
@@ -27,6 +30,7 @@ window.paginationControls = document.getElementById('paginationControls');
 window.shopListSection = document.getElementById('shopListSection');
 window.shopFormSection = document.getElementById('shopFormSection');
 window.vatToggle = document.getElementById('vatToggle');
+window.profitMarginInput = document.getElementById('profitMargin');
 
 // Initialisering af event listeners
 document.addEventListener('DOMContentLoaded', function() {
@@ -37,6 +41,13 @@ document.addEventListener('DOMContentLoaded', function() {
         window.includeVAT = e.target.checked;
         if (window.displayProducts) window.displayProducts();
     });
+    if (window.profitMarginInput) {
+        window.profitMarginPercent = parseFloat(window.profitMarginInput.value) || 0;
+        window.profitMarginInput.addEventListener('input', function(e) {
+            window.profitMarginPercent = parseFloat(e.target.value) || 0;
+            if (window.displayProducts) window.displayProducts();
+        });
+    }
 
     if (window.setupDragAndDrop) {
         window.setupDragAndDrop('parentUploadBox', 'parentFile', window.handleParentFile);

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -116,8 +116,10 @@ function displayProducts() {
             const basePrice = editedData.get(`${variation.sku}_price`) || variation.regular_price || '';
             let displayPrice = basePrice;
             const numPrice = parseFloat(basePrice);
-            if (!isNaN(numPrice) && includeVAT) {
-                displayPrice = (numPrice * (1 + VAT_RATE)).toFixed(2);
+            if (!isNaN(numPrice)) {
+                let priceWithProfit = applyProfitMargin(numPrice);
+                if (includeVAT) priceWithProfit *= (1 + VAT_RATE);
+                displayPrice = priceWithProfit.toFixed(2);
             }
             const currentCategory = editedData.get(`${parent.sku}_category`) || parent['tax:product_cat'] || '';
             variationRow.innerHTML = `
@@ -185,7 +187,8 @@ function sendToWooCommerce() {
         const item = combinedData.find(i => i.data.sku === sku && i.type === 'variation');
         if (item) {
             const priceGBP = editedData.get(`${sku}_price`) ?? item.data.regular_price;
-            const priceDKK = convertGBPtoDKK(priceGBP);
+            const withProfit = applyProfitMargin(priceGBP);
+            const priceDKK = convertGBPtoDKK(withProfit);
             productsToSend.push({ sku: sku, price: priceDKK });
         }
     });

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -56,8 +56,10 @@ function saveEdit(element) {
         value = value.replace('£', '');
         if (value && !isNaN(value)) {
             editedData.set(`${sku}_price`, value);
-            const num = parseFloat(value);
-            const displayValue = includeVAT ? (num * (1 + VAT_RATE)).toFixed(2) : value;
+            let num = parseFloat(value);
+            num = applyProfitMargin(num);
+            if (includeVAT) num = num * (1 + VAT_RATE);
+            const displayValue = num.toFixed(2);
             element.textContent = `£${displayValue}`;
             element.style.background = '#d1ecf1';
             setTimeout(() => { element.style.background = ''; }, 1000);


### PR DESCRIPTION
## Summary
- add Profit % field in UI
- store profitMarginPercent globally and listen for changes
- adjust displayed prices, CSV export, and WooCommerce send based on the margin
- apply profit margin when editing prices

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688cd76c60c4833398c3b897db369b38