### PR TITLE
Enable WooCommerce updates via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Product Viewer (Node.js)
 
-This project displays parent and variation products from CSV files and allows basic management features.
+This project displays parent and variation products from CSV files and allows basic management features. Selected products can be updated directly on your WooCommerce shops using the built in API endpoints.
 
 ## Setup
 
@@ -23,3 +23,10 @@ npm start
 ```
 
 The application will be available at http://localhost:3500 .
+
+## Updating products via API
+
+When products are selected in the UI, the "Send til WooCommerce" button will post
+the changes to `/api/products/{shopId}`. The server locates each product by SKU
+and updates the price and category on the chosen shop using the WooCommerce REST
+API.

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -189,17 +189,31 @@ function sendToWooCommerce() {
             const priceGBP = editedData.get(`${sku}_price`) ?? item.data.regular_price;
             const withProfit = applyProfitMargin(priceGBP);
             const priceDKK = convertGBPtoDKK(withProfit);
-            productsToSend.push({ sku: sku, price: priceDKK });
+            const category = editedData.get(`${item.parent.sku}_category`) ?? item.parent['tax:product_cat'];
+            productsToSend.push({ sku: sku, price: priceDKK, category });
         }
     });
 
-    alert(`Sender ${selectedProducts.size} produkter til ${shop.name}...\n\nDette er en demo. I en rigtig applikation ville dette sende produkterne via WooCommerce REST API.`);
     console.log('Produkter der sendes:', productsToSend);
 
-    selectedProducts.clear();
-    document.querySelectorAll('.product-checkbox').forEach(cb => (cb.checked = false));
-    document.getElementById('selectAll').checked = false;
-    updateSelectedCount();
-
-    alert('Produkter sendt til WooCommerce!');
+    fetch(`/api/products/${shop.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ products: productsToSend })
+    })
+        .then(res => res.json())
+        .then(data => {
+            alert('WooCommerce opdatering fuldført');
+            console.log('Resultater:', data);
+        })
+        .catch(err => {
+            alert('Fejl under opdatering');
+            console.error(err);
+        })
+        .finally(() => {
+            selectedProducts.clear();
+            document.querySelectorAll('.product-checkbox').forEach(cb => (cb.checked = false));
+            document.getElementById('selectAll').checked = false;
+            updateSelectedCount();
+        });
 }

--- a/server.js
+++ b/server.js
@@ -38,6 +38,63 @@ app.get('/api/products/:shopId', async (req, res) => {
   }
 });
 
+app.post('/api/products/:shopId', async (req, res) => {
+  const shop = shops.find((s) => s.id === req.params.shopId);
+  if (!shop) return res.status(404).json({ error: 'Shop not found' });
+
+  const updates = Array.isArray(req.body) ? req.body : req.body.products;
+  if (!Array.isArray(updates)) return res.status(400).json({ error: 'Invalid request body' });
+
+  const baseUrl = shop.url.replace(/\/$/, '');
+  const auth = `consumer_key=${shop.consumerKey}&consumer_secret=${shop.consumerSecret}`;
+  const results = [];
+
+  for (const item of updates) {
+    if (!item.sku) continue;
+    try {
+      const searchUrl = `${baseUrl}/wp-json/wc/v3/products?sku=${encodeURIComponent(item.sku)}&${auth}`;
+      const searchRes = await fetch(searchUrl);
+      const searchData = await searchRes.json();
+      const product = searchData && searchData[0];
+      if (!product) {
+        results.push({ sku: item.sku, error: 'not found' });
+        continue;
+      }
+
+      const updateUrl = `${baseUrl}/wp-json/wc/v3/products/${product.id}?${auth}`;
+      const body = {};
+      if (item.price) body.regular_price = String(item.price);
+      if (item.status) body.status = item.status;
+      if (item.category) {
+        try {
+          const catUrl = `${baseUrl}/wp-json/wc/v3/products/categories?search=${encodeURIComponent(item.category)}&${auth}`;
+          const catRes = await fetch(catUrl);
+          const categories = await catRes.json();
+          const cat = categories.find(c => c.name.toLowerCase() === item.category.toLowerCase());
+          if (cat) body.categories = [{ id: cat.id }];
+        } catch (e) {
+          console.error('Category lookup failed', e);
+        }
+      }
+      const updateRes = await fetch(updateUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      if (updateRes.ok) {
+        results.push({ sku: item.sku, status: 'updated' });
+      } else {
+        const errText = await updateRes.text();
+        results.push({ sku: item.sku, error: errText });
+      }
+    } catch (err) {
+      results.push({ sku: item.sku, error: err.message });
+    }
+  }
+
+  res.json({ results });
+});
+
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });


### PR DESCRIPTION
## Summary
- implement POST /api/products/:shopId for updating WooCommerce products
- send selected products from the UI to the new endpoint
- include category mapping in updates
- document update flow in README

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_688cdc10919c8333bdffd51ee10a0608