### PR TITLE
Update layout and collapse upload section

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -48,11 +48,19 @@
             gap: 10px;
         }
 
-        .file-upload {
-            background: #f8f9fa;
-            padding: 25px;
-            border-bottom: 1px solid #e9ecef;
-        }
+.file-upload {
+    background: #f8f9fa;
+    padding: 25px;
+    border-bottom: 1px solid #e9ecef;
+    transition: max-height 0.5s ease, padding 0.5s ease;
+    overflow: hidden;
+}
+
+.file-upload.collapsed {
+    max-height: 0;
+    padding: 0;
+    border: none;
+}
 
         .upload-section {
             display: flex;

--- a/public/index.html
+++ b/public/index.html
@@ -18,27 +18,6 @@
             </div>
         </div>
 
-        <div class="file-upload">
-            <div class="upload-section">
-                <div class="upload-box" id="parentUploadBox">
-                    <div class="upload-icon">📄</div>
-                    <h3>Parent Produkter</h3>
-                    <p>Træk CSV-fil hertil eller klik for at vælge</p>
-                    <input type="file" id="parentFile" accept=".csv" />
-                    <div class="file-status" id="parentStatus"></div>
-                    <div class="drag-overlay">📁 Slip filen her!</div>
-                </div>
-
-                <div class="upload-box" id="variationUploadBox">
-                    <div class="upload-icon">📊</div>
-                    <h3>Variationer</h3>
-                    <p>Træk CSV-fil hertil eller klik for at vælge</p>
-                    <input type="file" id="variationFile" accept=".csv" />
-                    <div class="file-status" id="variationStatus"></div>
-                    <div class="drag-overlay">📁 Slip filen her!</div>
-                </div>
-            </div>
-        </div>
 
         <div class="stats hidden" id="stats">
             <div class="stat-item">
@@ -155,6 +134,28 @@
                         <option value="100">100</option>
                         <option value="250">250</option>
                     </select>
+                </div>
+            </div>
+        </div>
+
+        <div class="file-upload" id="fileUploadSection">
+            <div class="upload-section">
+                <div class="upload-box" id="parentUploadBox">
+                    <div class="upload-icon">📄</div>
+                    <h3>Parent Produkter</h3>
+                    <p>Træk CSV-fil hertil eller klik for at vælge</p>
+                    <input type="file" id="parentFile" accept=".csv" />
+                    <div class="file-status" id="parentStatus"></div>
+                    <div class="drag-overlay">📁 Slip filen her!</div>
+                </div>
+
+                <div class="upload-box" id="variationUploadBox">
+                    <div class="upload-icon">📊</div>
+                    <h3>Variationer</h3>
+                    <p>Træk CSV-fil hertil eller klik for at vælge</p>
+                    <input type="file" id="variationFile" accept=".csv" />
+                    <div class="file-status" id="variationStatus"></div>
+                    <div class="drag-overlay">📁 Slip filen her!</div>
                 </div>
             </div>
         </div>

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -65,6 +65,7 @@ function processAndDisplayData() {
     document.getElementById('loading').classList.add('hidden');
     document.getElementById('productTable').classList.remove('hidden');
     paginationControls.classList.remove('hidden');
+    if (window.collapseUploadSection) collapseUploadSection();
 }
 
 function displayProducts() {

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -75,3 +75,8 @@ function saveEdit(element) {
         variations.forEach(cell => { cell.textContent = value; });
     }
 }
+
+function collapseUploadSection() {
+    const section = document.getElementById('fileUploadSection');
+    if (section) section.classList.add('collapsed');
+}


### PR DESCRIPTION
## Summary
- move product table above upload boxes
- collapse upload box section after loading files

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688d2120d7c08333b7f0e397d1295cbf