### PR TITLE
Add WooCommerce variation fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ the changes to `/api/products/{shopId}`. The server locates each product by SKU
 and updates the price and category on the chosen shop using the WooCommerce REST
 API.
 
+## Loading products from WooCommerce
+
+Selecting a shop now triggers a request to `/api/products/{shopId}` which
+fetches all products from the configured WooCommerce store. For each product the
+server also requests its variations so the response contains two arrays:
+`products` and `variations`. The client maps these and shows variation images in
+the product table.
+
 ## Shop management persistence
 
 The list of shops is stored in the browser's `localStorage`. When the page

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -22,6 +22,21 @@ function mapApiProduct(p) {
     };
 }
 
+function mapApiVariation(v) {
+    const colourAttr = v.attributes.find(a => /colour|color/i.test(a.name));
+    const sizeAttr = v.attributes.find(a => /size/i.test(a.name));
+    const imgSrc = (v.image && v.image.src) || (v.images && v.images[0] && v.images[0].src) || '';
+    return {
+        sku: v.sku,
+        stock_status: v.stock_status,
+        regular_price: v.regular_price,
+        'meta:attribute_Colour': colourAttr && (colourAttr.option || (colourAttr.options && colourAttr.options[0])),
+        'meta:attribute_Size': sizeAttr && (sizeAttr.option || (sizeAttr.options && sizeAttr.options[0])),
+        images: imgSrc,
+        parent_sku: v.parent_sku
+    };
+}
+
 async function loadProductsForShop(index) {
     const shop = shops[index];
     if (!shop) return;
@@ -29,7 +44,7 @@ async function loadProductsForShop(index) {
         const res = await fetch(`/api/products/${shop.id}`);
         const data = await res.json();
         parentData = data.products.map(mapApiProduct);
-        variationData = [];
+        variationData = data.variations.map(mapApiVariation);
         tryProcessData();
     } catch (err) {
         console.error('Failed to load products', err);


### PR DESCRIPTION
## Summary
- fetch products and their variations in server API
- map variations on the client and use them in the display
- show images for fetched variations
- document how products are now loaded directly from WooCommerce

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d2c6338748333a835e7a957bbd897